### PR TITLE
Replace unnecessary unwrap calls

### DIFF
--- a/src/console/ansi.rs
+++ b/src/console/ansi.rs
@@ -221,22 +221,20 @@ impl AnsiCode {
 
     fn enable(self) {
         let (pair, attr) = self.attr_pair();
-        if pair.is_some() {
-            let (id, _, _) = pair.unwrap();
+        if let Some((id, _, _)) = pair {
             attron(COLOR_PAIR(id));
         }
-        if attr.is_some() {
-            attron(attr.unwrap());
+        if let Some(attr) = attr {
+            attron(attr);
         }
     }
 
     fn disable(self) {
         let (pair, attr) = self.attr_pair();
-        if attr.is_some() {
-            attroff(attr.unwrap());
+        if let Some(attr) = attr {
+            attroff(attr);
         }
-        if pair.is_some() {
-            let (id, _, _) = pair.unwrap();
+        if let Some((id, _, _)) = pair {
             attroff(COLOR_PAIR(id));
         }
     }
@@ -366,8 +364,7 @@ impl StyledMessage {
             }
         }
 
-        if last_code.is_some() {
-            let last_code = last_code.unwrap();
+        if let Some(last_code) = last_code {
             if last_code != AnsiCode::Reset {
                 result.push_str(AnsiCode::Reset.ansi_code());
             }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -690,7 +690,7 @@ impl Completions {
             if i >= self.lines {
                 break;
             }
-            let current_index_selected = self.index.is_some() && i == self.index.unwrap();
+            let current_index_selected = self.index.map_or(false, |idx| i == idx);
             if current_index_selected {
                 wattroff(self.window, COLOR_PAIR(COMPLETE_TEXT_PAIR));
                 wattron(self.window, COLOR_PAIR(COMPLETE_SELECTED_PAIR));
@@ -714,13 +714,13 @@ impl Completions {
     fn handle_key(&mut self, ch: i32) -> (Option<String>, u8) {
         match ch {
             KEY_UP => {
-                if self.index.is_none() || self.index.unwrap() < self.lines - 1 {
+                if self.index.map_or(true, |idx| idx < self.lines - 1) {
                     self.index = Some(self.index.unwrap_or(0) + 1);
                     self.redraw();
                 }
             }
             KEY_DOWN => {
-                if self.index.is_some() && self.index.unwrap() > 0 {
+                if self.index.map_or(false, |idx| idx > 0) {
                     self.index = Some(self.index.unwrap() - 1);
                     self.redraw();
                 }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -730,11 +730,12 @@ impl Completions {
                 return (Some(result), Completions::NO_ACTION);
             }
             NORMAL_KEY_ENTER | KEY_ENTER => {
-                return if self.index.is_none() {
-                    (None, Completions::CLOSE_WINDOW | Completions::SEND_KEY)
-                } else {
-                    let result = self.suggestions[self.index.unwrap()].clone();
-                    (Some(result), Completions::NO_ACTION)
+                return match self.index {
+                    Some(idx) => {
+                        let result = self.suggestions[idx].clone();
+                        (Some(result), Completions::NO_ACTION)
+                    },
+                    None => (None, Completions::CLOSE_WINDOW | Completions::SEND_KEY),
                 }
             }
             27 | CTRL_F => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -279,8 +279,7 @@ fn setup_java_env(sub_m: &ArgMatches) -> Result<JavaEnv, i32> {
     };
 
     // Replace shell variables in config file values if they are present
-    if config.is_some() {
-        let config = config.as_mut().unwrap();
+    if Some(config) = config.as_mut() {
         let map_func = |text: String| {
             shellexpand::env_with_context(text.as_str(), shell_context)
                 .unwrap()

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -38,15 +38,15 @@ pub fn timings(sub_m: &ArgMatches) -> Result<(), i32> {
         if res.done {
             break;
         }
-        if res.message.is_some() {
+        if let Some(msg) = res.message {
             #[cfg(feature = "console")]
             println!(
                 "{}",
-                ansi::StyledMessage::parse(res.message.unwrap().as_str()).get_string()
+                ansi::StyledMessage::parse(msg.as_str()).get_string()
             );
 
             #[cfg(not(feature = "console"))]
-            println!("{}", mc_colors(res.message.unwrap().as_str()));
+            println!("{}", mc_colors(msg.as_str()));
         }
     }
 


### PR DESCRIPTION
Replace `unwrap` with `if let`, `match`, and `map_or`